### PR TITLE
chore(renovate): enable dependency updates

### DIFF
--- a/.github/linters/zizmor.yaml
+++ b/.github/linters/zizmor.yaml
@@ -1,0 +1,18 @@
+rules:
+  dangerous-triggers:
+    ignore:
+      - cla.yaml
+      - pr-assigner.yml
+  secrets-outside-env:
+    ignore:
+      - automatic-pr-labeler.yaml
+      - build.yaml
+      - cla.yaml
+      - link-checker.yaml
+      - ossf-scorecard.yaml
+      - pr-conventional-commits.yaml
+      - pr-lint-title.yaml
+      - profanity-filter.yaml
+      - renovate-config-lint.yaml
+      - security-scan.yml
+      - super-linter.yaml

--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -1,0 +1,27 @@
+name: Validate Renovate Config
+run-name: "Ref: ${{ github.ref_name }}. On ${{ github.event_name }}"
+
+on:
+  push:
+    paths:
+      - renovate.json
+      - .github/workflows/renovate-config-lint.yaml
+  pull_request:
+    paths:
+      - renovate.json
+      - .github/workflows/renovate-config-lint.yaml
+
+jobs:
+  validate-renovate-config:
+    name: Validate renovate.json
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Validate renovate.json
+        run: docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator --strict --no-global renovate.json

--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -15,6 +15,9 @@ jobs:
   validate-renovate-config:
     name: Validate renovate.json
     runs-on: ubuntu-latest
+    container:
+      image: renovate/renovate:43.285.4@sha256:bd7d8f646bf9d22aea995eaad06ec26c3f4fd4efbc36826024f5653006c9e7b1
+      options: --user 0
     permissions:
       contents: read
     steps:
@@ -24,4 +27,24 @@ jobs:
           persist-credentials: false
 
       - name: Validate renovate.json
-        run: docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator --strict --no-global renovate.json
+        run: renovate-config-validator --strict --no-global renovate.json
+
+      - name: Resolve shared Renovate presets
+        shell: bash
+        env:
+          GITHUB_COM_TOKEN: ${{ github.token }}
+          LOG_FORMAT: json
+          LOG_LEVEL: warn
+        run: |
+          set -o pipefail
+          log_file="$(mktemp)"
+          trap 'rm -f "$log_file"' EXIT
+          validation_filter='fromjson? | select(.err.validationError? or .msg == "Repository has invalid config")'
+
+          renovate --platform=local --dry-run=extract 2>&1 | tee "$log_file"
+
+          if jq -R -e "$validation_filter" "$log_file" >/dev/null; then
+            echo "::error::Renovate could not resolve the repository configuration"
+            jq -R -r "$validation_filter | .err.validationError // .msg" "$log_file"
+            exit 1
+          fi

--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,12 @@
     "github>Netcracker/renovate-config:github-actions",
     "github>Netcracker/renovate-config:netcracker-dependencies",
     "github>Netcracker/renovate-config:graylog-plugins"
+  ],
+  "packageRules": [
+    {
+      "description": "Keep TelegramAlert compatible with Graylog 5",
+      "matchPackageNames": ["irgendwr/TelegramAlert"],
+      "allowedVersions": "<2.5.0"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>Netcracker/renovate-config:base",
+    "github>Netcracker/renovate-config:github-actions",
+    "github>Netcracker/renovate-config:netcracker-dependencies",
+    "github>Netcracker/renovate-config:graylog-plugins"
+  ]
+}


### PR DESCRIPTION
## Why

The repository needs organization-standard dependency updates and configuration validation. TelegramAlert 2.5.0 and later require Graylog 6, while this stack remains on Graylog 5.

## What

- Add the shared base, GitHub Actions, Netcracker dependency, and Graylog plugin presets.
- Keep TelegramAlert below 2.5.0 for Graylog 5 compatibility.
- Add strict Renovate configuration validation.
- Use the compatible Zizmor rule schema required by the existing CI.

Related shared configuration: [Netcracker/renovate-config#29](https://github.com/Netcracker/renovate-config/pull/29), [Netcracker/renovate-config#31](https://github.com/Netcracker/renovate-config/pull/31), and [Netcracker/renovate-config#32](https://github.com/Netcracker/renovate-config/pull/32).
