### PR TITLE
ci: add container runtime gate

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,76 +1,201 @@
 ---
 name: Build Artifacts
+run-name: "Ref: ${{ github.ref_name }}. On ${{ github.event_name }}"
 
 on:
   release:
     types: [created]
   push:
     branches:
-    - '**'
-    paths-ignore:
-    - '.github/**'
-    - 'docs/**'
-    - '*.md'
-    - 'LICENSE'
+      - main
   pull_request:
     branches:
-    - '**'
-    paths-ignore:
-    - '.github/**'
-    - 'docs/**'
-    - '*.md'
-    - 'LICENSE'
+      - "**"
+
+permissions: {}
 
 concurrency:
-  # On main/release, we don't want any jobs cancelled so the sha is used to name the group
-  # On PR branches, we cancel the job if new commits are pushed
-  # More info: https://stackoverflow.com/a/68422069/253468
-  group: ${{ github.ref == 'refs/heads/main' && format('ci-main-{0}', github.sha) || format('ci-main-{0}', github.ref) }}
-  cancel-in-progress: true
+  group: ${{ github.event_name == 'pull_request' && format('build-pr-{0}', github.ref) || format('build-{0}', github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  multiplatform_build:
-    if: github.event.pull_request.user.login != 'dependabot[bot]' || github.event_name == 'pull_request'
-    strategy:
-      fail-fast: false
-      matrix:
-        component:
-        - name: qubership-graylog-plugins-init
-          file: Dockerfile
-          context: .
+  changes:
+    name: Detect relevant changes
     runs-on: ubuntu-latest
-    name: ${{ matrix.component.name }}
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      container: ${{ github.event_name == 'release' || steps.filter.outputs.container }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Docker meta
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: |
-          ghcr.io/${{ github.repository_owner }}/${{ matrix.component.name }}
-        tags: |
-          type=ref,event=branch
-          type=ref,event=tag
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build and push
-      uses: docker/build-push-action@v6
-      with:
-        no-cache: true
-        context: ${{ matrix.component.context }}
-        file: ${{ matrix.component.file }}
-        platforms: linux/amd64,linux/arm64
-        # See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#fetching-metadata-about-a-pull-request
-        push: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
-        provenance: false
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+      - name: Checkout push
+        if: github.event_name == 'push'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 100
+          persist-credentials: false
+      - name: Detect changed paths
+        id: filter
+        if: github.event_name != 'release'
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          base: ${{ github.ref }}
+          filters: |
+            container:
+              - '.github/workflows/build.yaml'
+              - 'Dockerfile'
+              - 'download_plugins.sh'
+              - 'entrypoint.sh'
+              - 'plugins.list'
+              - 'tests/test_download_plugins.sh'
+
+  runtime_smoke:
+    name: Build and smoke-test container
+    needs: changes
+    if: needs.changes.outputs.container == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Test plugin downloader
+        run: tests/test_download_plugins.sh
+      - name: Build test image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          load: true
+          no-cache: true
+          platforms: linux/amd64
+          provenance: false
+          push: false
+          tags: qubership-graylog-plugins-init:ci
+      - name: Verify plugin copy contract
+        run: |
+          set -euo pipefail
+
+          plugin_dir=$(mktemp -d)
+          trap 'rm -rf "$plugin_dir"' EXIT
+          chmod 0777 "$plugin_dir"
+
+          docker run --rm \
+            --volume "$plugin_dir:/usr/share/graylog/plugin" \
+            qubership-graylog-plugins-init:ci
+
+          expected_count=0
+          while IFS= read -r plugin_url || [[ -n "$plugin_url" ]]; do
+            if [[ -z "$plugin_url" || "$plugin_url" == \#* ]]; then
+              continue
+            fi
+
+            plugin_name=$(basename -- "$plugin_url")
+            if [[ ! -s "$plugin_dir/$plugin_name" ]]; then
+              echo "Expected plugin was not copied as a non-empty top-level file: $plugin_name" >&2
+              exit 1
+            fi
+            expected_count=$((expected_count + 1))
+          done < plugins.list
+
+          if [[ "$expected_count" -eq 0 ]]; then
+            echo "plugins.list does not contain any plugin URLs" >&2
+            exit 1
+          fi
+
+          if find "$plugin_dir" -mindepth 1 -maxdepth 1 -type d -print -quit | grep -q .; then
+            echo "Plugin output contains an unexpected nested directory" >&2
+            find "$plugin_dir" -mindepth 1 -maxdepth 2 -print >&2
+            exit 1
+          fi
+
+          actual_count=$(find "$plugin_dir" -mindepth 1 -maxdepth 1 -type f | wc -l)
+          if [[ "$actual_count" -ne "$expected_count" ]]; then
+            echo "Expected $expected_count plugin files, found $actual_count" >&2
+            exit 1
+          fi
+
+  publish_image:
+    name: Publish container image
+    needs: [changes, runtime_smoke]
+    if: >-
+      (github.event_name == 'release' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')) &&
+      needs.changes.result == 'success' &&
+      needs.runtime_smoke.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Create image metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/qubership-graylog-plugins-init
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push container image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          no-cache: true
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  ci_gate:
+    name: Graylog Plugins Init CI Gate
+    needs: [changes, runtime_smoke]
+    if: always() && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Verify required jobs
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CONTAINER_REQUIRED: ${{ needs.changes.outputs.container }}
+          SMOKE_RESULT: ${{ needs.runtime_smoke.result }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "Change detection did not succeed: $CHANGES_RESULT"
+            exit 1
+          fi
+
+          if [[ "$CONTAINER_REQUIRED" == "true" && "$SMOKE_RESULT" != "success" ]]; then
+            echo "The container smoke test was required but did not succeed: $SMOKE_RESULT"
+            exit 1
+          fi
+          if [[ "$CONTAINER_REQUIRED" != "true" && "$SMOKE_RESULT" != "skipped" ]]; then
+            echo "The container smoke test was not required but had an unexpected result: $SMOKE_RESULT"
+            exit 1
+          fi

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -14,7 +14,7 @@ name: Lint Code Base
 on:
   push:
     branches:
-      - '**'
+      - main
   pull_request:
     branches:
       - '**'
@@ -89,10 +89,9 @@ jobs:
         fi
 
     - name: Lint Code Base
-      uses: super-linter/super-linter/slim@ffde3b2b33b745cb612d787f669ef9442b1339a6 # v8.1.0
+      uses: super-linter/super-linter/slim@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
       env:
         VALIDATE_ALL_CODEBASE: ${{ inputs.full_scan || false }}
         # To report GitHub Actions status checks
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         DEFAULT_BRANCH: ${{ github.event.pull_request.base.ref || github.event.push.ref }}
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY ./download_plugins.sh ./plugins.list /
 
 RUN apk add \
         bash \
+        ca-certificates \
         wget \
         unzip \
     && chmod +x /download_plugins.sh \

--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ Structure of init image:
 
 ## How to add plugin
 
-There is file `plugins.list` which contains plugin link.
-Currently plugins can be download only from:
+The `plugins.list` file contains one plugin URL per line. Each URL must point to a JAR asset in a GitHub release over
+HTTPS. The image build rejects other hosts and verifies TLS certificates before downloading a plugin.
 
-* [https://community.graylog.org/c/marketplace/31](https://community.graylog.org/c/marketplace/31)
+Find available plugins in the [Graylog Marketplace](https://community.graylog.org/c/marketplace/31), then use the
+plugin project's GitHub release URL.
 
 Format:
 

--- a/download_plugins.sh
+++ b/download_plugins.sh
@@ -1,31 +1,43 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 ######################################################################################################################
 #                                                      Constants                                                     #
 ######################################################################################################################
 
-TEMP_PATH="/tmp"
-DOWNLOADS_PATH="${TEMP_PATH}/plugins"
+readonly DOWNLOADS_PATH="${PLUGIN_DOWNLOADS_PATH:-/tmp/plugins}"
+readonly PLUGINS_FILE="${PLUGINS_FILE:-plugins.list}"
+readonly GITHUB_RELEASE_URL_PATTERN='^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/releases/download/[^/?#[:space:]]+/[A-Za-z0-9_.+-]+\.jar$'
 
 ######################################################################################################################
 #                                                  Download plugins                                                  #
 ######################################################################################################################
 
-mkdir -p ${DOWNLOADS_PATH}
+mkdir -p "${DOWNLOADS_PATH}"
 
 echo "Start to read file with plugins ..."
 while IFS='' read -r line || [[ -n "${line}" ]]; do
-    if [[ "${line}" != \#* ]]; then
-        filename=$(basename "${line}")
+    if [[ -n "${line}" && "${line}" != \#* ]]; then
+        if [[ ! "${line}" =~ ${GITHUB_RELEASE_URL_PATTERN} ]]; then
+            echo "Unsupported plugin URL: ${line}" >&2
+            echo "Use an HTTPS JAR URL from a GitHub release." >&2
+            exit 1
+        fi
+
+        filename=$(basename -- "${line}")
 
         echo "Try to download plugin: ${filename} ..."
-        wget --no-check-certificate -P "${DOWNLOADS_PATH}/${filename}" \
-            -r -nd --quiet --no-parent \
+        wget --quiet \
+            --output-document "${DOWNLOADS_PATH}/${filename}" \
             "${line}"
+
+        if [[ ! -s "${DOWNLOADS_PATH}/${filename}" ]]; then
+            echo "Downloaded plugin is empty: ${filename}" >&2
+            exit 1
+        fi
     fi
-done <"plugins.list"
+done <"${PLUGINS_FILE}"
 echo "Plugins successfully downloaded"
 
 echo "List of plugins directories:"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,9 +9,9 @@ GRAYLOG_PLUGINS_DIR=/usr/share/graylog/plugin
 echo "Start graylog-plugins-init container..."
 
 echo "Available plugins:"
-ls -lah ${LOCAL_PLUGINS_DIR}
+ls -lah "${LOCAL_PLUGINS_DIR}"
 
 echo "Copy plugins from ${LOCAL_PLUGINS_DIR} to ${GRAYLOG_PLUGINS_DIR} (which should be mounted as a volume)..."
-cp -r "${LOCAL_PLUGINS_DIR}" "${GRAYLOG_PLUGINS_DIR}"
+cp -r "${LOCAL_PLUGINS_DIR}/." "${GRAYLOG_PLUGINS_DIR}/"
 
 echo "Plugins are successfully copied"

--- a/tests/test_download_plugins.sh
+++ b/tests/test_download_plugins.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPOSITORY_ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+readonly REPOSITORY_ROOT
+TEST_ROOT=$(mktemp -d)
+readonly TEST_ROOT
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+mkdir -p "$TEST_ROOT/bin"
+cat >"$TEST_ROOT/bin/wget" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+output=''
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --no-check-certificate)
+            echo 'TLS certificate verification was disabled' >&2
+            exit 1
+            ;;
+        --output-document)
+            output=$2
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+printf 'plugin-content\n' >"$output"
+EOF
+chmod +x "$TEST_ROOT/bin/wget"
+
+run_downloader() {
+    local fixture=$1
+    local downloads=$2
+
+    PLUGINS_FILE="$fixture" \
+        PLUGIN_DOWNLOADS_PATH="$downloads" \
+        PATH="$TEST_ROOT/bin:$PATH" \
+        "$REPOSITORY_ROOT/download_plugins.sh"
+}
+
+valid_list="$TEST_ROOT/valid.list"
+cat >"$valid_list" <<'EOF'
+# Comments and blank lines are allowed.
+
+https://github.com/example/plugin/releases/download/1.0.0/plugin-1.0.0.jar
+EOF
+run_downloader "$valid_list" "$TEST_ROOT/valid-downloads"
+test -s "$TEST_ROOT/valid-downloads/plugin-1.0.0.jar"
+
+invalid_source_list="$TEST_ROOT/invalid-source.list"
+cat >"$invalid_source_list" <<'EOF'
+https://example.com/plugin-1.0.0.jar
+EOF
+if run_downloader "$invalid_source_list" "$TEST_ROOT/invalid-source-downloads"; then
+    echo 'Downloader accepted a plugin outside GitHub Releases' >&2
+    exit 1
+fi


### PR DESCRIPTION
## Why

The repository builds and publishes a plugin init image, but its pull-request workflow does not expose a stable functional gate. The existing build also does not verify that the entrypoint copies non-empty JAR files into the mounted Graylog plugin directory, and it disables TLS certificate verification while downloading plugins.

## What

- Add fail-closed path detection and an always-present `Graylog Plugins Init CI Gate` for pull requests.
- Build a nonpublishing `linux/amd64` test image and verify that every configured plugin is copied as a non-empty top-level JAR file.
- Keep registry login, package write access, and multi-platform publication limited to release events and relevant pushes to `main`.
- Download plugins only from HTTPS GitHub release URLs with TLS certificate verification enabled.
- Add downloader regression coverage and update Super-Linter to the v8.7.0 compatibility baseline.

## How to verify

- Run `tests/test_download_plugins.sh`.
- Run `shellcheck download_plugins.sh entrypoint.sh tests/test_download_plugins.sh`.
- Run `actionlint .github/workflows/build.yaml .github/workflows/super-linter.yaml`.
- Run `docker build --check .` and `docker build --no-cache -t qubership-graylog-plugins-init:ci .`.
- Start the image with a writable volume mounted at `/usr/share/graylog/plugin` and verify that both configured JAR files are copied directly into the volume.

Closes #30
